### PR TITLE
Create 商品出品ページ3(中村)

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -25,3 +25,5 @@
 
 # Ignore master key for decrypting credentials and more.
 /config/master.key
+
+public/uploads/*

--- a/app/controllers/products_controller.rb
+++ b/app/controllers/products_controller.rb
@@ -5,15 +5,16 @@ class ProductsController < ApplicationController
 
   def new
     @product = Product.new
-    @product_image = Product_image.new
+    @product.product_images.new
   end
 
   def create
-    Product.create(product_params)
-    redirect_to root_path
-
-    # Product_image.create(product_image_params)
-    # redirect_to root_path
+    @product = Product.new(product_params)
+    if @product.save
+      redirect_to root_path
+    else
+      render :new
+    end
   end
 
   def show
@@ -31,10 +32,7 @@ class ProductsController < ApplicationController
 
   private
   def product_params
-    params.require(:product).permit(:name, :detail,:condition,:delivery_fee,:shipping_area,:shipping_days,:price,:existence).merge(user_id: current_user.id)
+    params.require(:product).permit(:name, :detail,:condition,:delivery_fee,:shipping_area,:shipping_days,:price,:existence,product_images_attributes: [:image]).merge(user_id: current_user.id)
   end
 
-  def product_image_params
-    params.require(:product_image).permit(:image).merge(:product_id)
-  end
 end

--- a/app/models/product.rb
+++ b/app/models/product.rb
@@ -1,4 +1,6 @@
 class Product < ApplicationRecord
   has_many :product_images
   belongs_to :user
+
+  accepts_nested_attributes_for :product_images, allow_destroy: true
 end

--- a/app/views/products/new.html.haml
+++ b/app/views/products/new.html.haml
@@ -3,23 +3,20 @@
 .products_new-main
   .products_new-main__form
     .products_new-main__form--product_image
-      = form_with model: @product_image, local: true, id:"new_image" do |form|
+      = form_with model: @product, local: true, id:"new_product" do |form|
         .products_new-newimage
           .products_new-product__headline
             .products_new-product__headline--title 出品画像
             .products_new-product__headline--required 必須
           %p.products_new-product__explanation 最大10枚までアップロードできます
           .products_new-imagearea
-            = form.label :image, class: 'products_new-imagearea__select' do
-              = icon('fas', 'camera', class: 'products_new-imagearea__select--icon')
-              %p.products_new-imagearea__select--explanation
-                ドラッグアンドドロップ
-                %br またはクリックしてファイルをアップロード
-            = form.file_field :image, style: "display: none;"
-        .products_new-product__image--submit
-          = form.submit '出品する', class: "products_new-product__image--submit--btn"
-    .products_new-main__form--product
-      = form_with model: @product, local: true, id:"new_product" do |form|
+            = form.fields_for :product_images do |i|
+              = i.file_field :image, style: "display: none;"
+              = i.label :image, class: 'products_new-imagearea__select' do
+                = icon('fas', 'camera', class: 'products_new-imagearea__select--icon')
+                %p.products_new-imagearea__select--explanation
+                  ドラッグアンドドロップ
+                  %br またはクリックしてファイルをアップロード
         .products_new-title
           .products_new-product__headline
             .products_new-product__headline--title 商品名


### PR DESCRIPTION
# What
商品詳細ページからproductsテーブルとそれに紐付くproduct_imagesテーブルに、一度にそれぞれデータを保存できるようにした。
product_imagesテーブル→画像データのみ保存
productsテーブル→それ以外の商品情報を保存

画像ファイルはgitで管理が必要ないため、gitignoreにその旨記述