### PR TITLE
Create 商品出品ページ、商品編集ページ(中村)

### DIFF
--- a/app/assets/javascripts/products_edit.js
+++ b/app/assets/javascripts/products_edit.js
@@ -51,11 +51,10 @@ $(function(){
 
   // 削除ボタンの設定
   $('.products_edit-image-box').on('click', '.products_edit-js-remove', function() {
-    const targetIndex = $(this).prev().data('index');
-    // 該当indexを振られているチェックボックスを取得する
-    const hiddenCheck = $(`input[data-index="${targetIndex}"].products_edit-hidden-destroy`);
+    const targetIndex = $(this).parent().parent().data('index');
     // もしチェックボックスが存在すればチェックを入れる
-    if (hiddenCheck) hiddenCheck.prop('checked', true);
+    $(`.delete-check-box-${targetIndex}`).prop('checked', true);
+    // if (hiddenCheck) hiddenCheck.prop('checked', true);
     $(this).parent().parent().remove();
     $(`div[data-index="${targetIndex}"]`).remove();
     // 画像入力欄が0個にならないようにしておく

--- a/app/assets/javascripts/products_edit.js
+++ b/app/assets/javascripts/products_edit.js
@@ -3,7 +3,7 @@ $(function(){
   const buildImg = (index, url)=> {
     const html = `<div data-index="${index}", class="products_edit-preview-box">
                     <div class="products_edit-upper-box">
-                      <img class= "image${index} product_edit-input_images", data-index="${index}" src="${url}" width="100px" height="100px">
+                      <img class= "image${index} products_edit-input_images", data-index="${index}" src="${url}" width="100px" height="100px">
                       <div class="products_edit-js-remove">
                         削除
                       </div>
@@ -13,10 +13,10 @@ $(function(){
   }
   // 画像用のinputを生成する関数
   const buildFileField = (num)=> {
-    const html = `<div data-index="${num}" class="product_edit-js-file_group">
-                    <input class="product_edit-js-file" type="file"
+    const html = `<div data-index="${num}" class="products_edit-js-file_group">
+                    <input class="products_edit-js-file" type="file"
                     name="product[product_images_attributes][${num}][image]"
-                    id="product_images_attributes_${num}_image"
+                    id="products_images_attributes_${num}_image"
                     style="display:none;">
                   </div>`;
     return html;
@@ -24,12 +24,12 @@ $(function(){
   // file_fieldのnameに動的なindexをつける為の配列
   let fileIndex = [1,2,3,4,5,6,7,8,9,10];
   // 既に使われているindexを除外
-  lastIndex = $('.product_edit-js-file_group:last').data('index');
+  lastIndex = $('.products_edit-js-file_group:last').data('index');
   fileIndex.splice(0, lastIndex);
 
-  $('.product_edit-hidden-destroy').hide();
+  $('.products_edit-hidden-destroy').hide();
   
-  $('.products_edit-image-box').on('change', '.product_edit-js-file', function(e) {
+  $('.products_edit-image-box').on('change', '.products_edit-js-file', function(e) {
     const targetIndex = $(this).parent().data('index');
     // ファイルのブラウザ上でのURLを取得する
     const file = e.target.files[0];
@@ -53,12 +53,12 @@ $(function(){
   $('.products_edit-image-box').on('click', '.products_edit-js-remove', function() {
     const targetIndex = $(this).prev().data('index');
     // 該当indexを振られているチェックボックスを取得する
-    const hiddenCheck = $(`input[data-index="${targetIndex}"].product_edit-hidden-destroy`);
+    const hiddenCheck = $(`input[data-index="${targetIndex}"].products_edit-hidden-destroy`);
     // もしチェックボックスが存在すればチェックを入れる
     if (hiddenCheck) hiddenCheck.prop('checked', true);
     $(this).parent().parent().remove();
     $(`div[data-index="${targetIndex}"]`).remove();
     // 画像入力欄が0個にならないようにしておく
-    if ($('.product_edit-js-file').length == 0) $('.products_edit-lower-box__label').prepend(buildFileField(fileIndex[0]));
+    if ($('.products_edit-js-file').length == 0) $('.products_edit-lower-box__label').prepend(buildFileField(fileIndex[0]));
   });
 });

--- a/app/assets/javascripts/products_new.js
+++ b/app/assets/javascripts/products_new.js
@@ -12,8 +12,8 @@ $(function(){
     return html;
   }
   const buildFileField = (num)=> {
-    const html = `<div data-index="${num}" class="product_new-js-file_group">
-                    <input class="product_new-js-file" type="file"
+    const html = `<div data-index="${num}" class="products_new-js-file_group">
+                    <input class="products_new-js-file" type="file"
                     name="product[product_images_attributes][${num}][image]"
                     id="product_images_attributes_${num}_image"
                     style= "display:none;">
@@ -22,8 +22,10 @@ $(function(){
   }
   // file_fieldのnameに動的なindexをつける為の配列
   let fileIndex = [1,2,3,4,5,6,7,8,9,10];
+  lastIndex = $('.products_new-js-file_group:last').data('index');
+  fileIndex.splice(0, lastIndex);
 
-  $('.products_new-image-box').on('change', '.product_new-js-file', function(e) {
+  $('.products_new-image-box').on('change', '.products_new-js-file', function(e) {
     const targetIndex = $(this).parent().data('index');
     // ファイルのブラウザ上でのURLを取得する
     const file = e.target.files[0];
@@ -39,6 +41,6 @@ $(function(){
 
   $('.products_new-image-box').on('click', '.products_new-js-remove', function() {
     $(this).parent().parent().remove();
-    if ($('.product_new-js-file').length == 0) $('.products_new-image-box').append(buildFileField(fileIndex[0]));
+    if ($('.products_new-js-file').length == 0) $('.products_new-image-box').append(buildFileField(fileIndex[0]));
   });
 });

--- a/app/assets/javascripts/products_new.js
+++ b/app/assets/javascripts/products_new.js
@@ -24,6 +24,7 @@ $(function(){
   let fileIndex = [1,2,3,4,5,6,7,8,9,10];
   lastIndex = $('.products_new-js-file_group:last').data('index');
   fileIndex.splice(0, lastIndex);
+  $('.products_new-hidden-destroy').hide();
 
   $('.products_new-image-box').on('change', '.products_new-js-file', function(e) {
     const targetIndex = $(this).parent().data('index');
@@ -40,7 +41,13 @@ $(function(){
   });
 
   $('.products_new-image-box').on('click', '.products_new-js-remove', function() {
+    const targetIndex = $(this).prev().data('index');
+    // 該当indexを振られているチェックボックスを取得する
+    const hiddenCheck = $(`input[data-index="${targetIndex}"].products_new-hidden-destroy`);
+    // もしチェックボックスが存在すればチェックを入れる
+    if (hiddenCheck) hiddenCheck.prop('checked', true);
     $(this).parent().parent().remove();
+    $(`div[data-index="${targetIndex}"]`).remove();
     if ($('.products_new-js-file').length == 0) $('.products_new-image-box').append(buildFileField(fileIndex[0]));
   });
 });

--- a/app/assets/stylesheets/application.scss
+++ b/app/assets/stylesheets/application.scss
@@ -23,3 +23,4 @@
 @import "modules/credit_cards.new";
 @import "products/edit";
 @import "modules/credit_cards.show";
+@import "modules/flash";

--- a/app/assets/stylesheets/modules/_flash.scss
+++ b/app/assets/stylesheets/modules/_flash.scss
@@ -1,0 +1,13 @@
+.notification {
+  .alert {
+    height: 50px;
+    width: 100%;
+    background-color: #ee827c;
+    color: #fff;
+    border: 1px solid #c9171e;
+    text-align: center;
+    margin-bottom: 20px;
+    border-radius: 3px;
+    line-height: 50px;
+  }
+}

--- a/app/controllers/products_controller.rb
+++ b/app/controllers/products_controller.rb
@@ -123,7 +123,7 @@ class ProductsController < ApplicationController
 
   private
   def product_params
-    params.require(:product).permit(:name, :detail,:condition,:category_id,:delivery_fee,:shipping_area,:shipping_days,:price,product_images_attributes: [:src, :_destroy, :id, :product_id, :image]).merge(user_id: current_user.id)
+    params.require(:product).permit(:name, :detail,:condition,:category_id,:delivery_fee,:shipping_area,:shipping_days,:price,product_images_attributes: [:image, :_destroy, :id]).merge(user_id: current_user.id)
   end
 
   def move_to_index

--- a/app/controllers/products_controller.rb
+++ b/app/controllers/products_controller.rb
@@ -15,24 +15,8 @@ class ProductsController < ApplicationController
     if @product.save
       redirect_to root_path
     else
-      grandchild_category = @product.category
-    child_category = grandchild_category.parent
-
-    @category_parent_array = []
-    Category.where(ancestry: nil).each do |parent|
-      @category_parent_array << parent.name
-    end
-
-    @category_children_array = []
-    Category.where(ancestry: child_category.ancestry).each do |children|
-      @category_children_array << children
-    end
-
-    @category_grandchildren_array = []
-    Category.where(ancestry: grandchild_category.ancestry).each do |grandchildren|
-      @category_grandchildren_array << grandchildren
-    end
-      render :new
+      flash[:alert] = '投稿に失敗しました'
+      redirect_to action: 'new'
     end
   end
 
@@ -66,8 +50,16 @@ class ProductsController < ApplicationController
 
   def update
     product = Product.find(params[:id])
-    product.update(product_params)
-    redirect_to product_path(product.id)
+    if product.user_id == current_user.id
+      if product.update(product_params)
+        redirect_to product_path(product.id)
+      else
+        flash[:alert] = '投稿に失敗しました'
+        redirect_to action: 'edit'
+      end
+    else
+      render product_path(@product.id)
+    end
   end
 
   def destroy

--- a/app/controllers/products_controller.rb
+++ b/app/controllers/products_controller.rb
@@ -15,11 +15,23 @@ class ProductsController < ApplicationController
     if @product.save
       redirect_to root_path
     else
-      @product.product_images.new
-      @category_parent_array = ["選択してください"]
-      Category.where(ancestry: nil).each do |parent|
-        @category_parent_array << parent.name
-      end
+      grandchild_category = @product.category
+    child_category = grandchild_category.parent
+
+    @category_parent_array = []
+    Category.where(ancestry: nil).each do |parent|
+      @category_parent_array << parent.name
+    end
+
+    @category_children_array = []
+    Category.where(ancestry: child_category.ancestry).each do |children|
+      @category_children_array << children
+    end
+
+    @category_grandchildren_array = []
+    Category.where(ancestry: grandchild_category.ancestry).each do |grandchildren|
+      @category_grandchildren_array << grandchildren
+    end
       render :new
     end
   end

--- a/app/views/layouts/_notifications.html.haml
+++ b/app/views/layouts/_notifications.html.haml
@@ -1,0 +1,3 @@
+.notification
+  - flash.each do |key, value|
+    = content_tag :div, value, class: key

--- a/app/views/products/edit.html.haml
+++ b/app/views/products/edit.html.haml
@@ -15,16 +15,16 @@
                   - @product.product_images.each_with_index do |image, i|
                     .products_edit-preview-box{"data-index" => "#{i}"}
                       .products_edit-upper-box
-                        = image_tag image.image.url, width: "100", height: "100", alt: "preview", class: "product_edit-input_images"
+                        = image_tag image.image.url, width: "100", height: "100", alt: "preview", class: "products_edit-input_images"
                         .products_edit-js-remove
                           削除
                 = form.fields_for :product_images do |image|
                   - if @product.persisted?
-                    = image.check_box :_destroy, include_hidden: false, data:{ index: image.index },class: 'product_edit-hidden-destroy'
+                    = image.check_box :_destroy, include_hidden: false, data:{ index: image.index },class: 'products_edit-hidden-destroy'
               .products_edit-lower-box
                 %label.products_edit-lower-box__label
-                  .product_edit-js-file_group{"data-index" => "#{@product.product_images.count}"}
-                    = form.file_field :image, name: "product[product_images_attributes][#{@product.product_images.count}][image]", id: "product_images_attributes_#{@product.product_images.count}_image", class: 'product_edit-js-file', style: "display:none"
+                  .products_edit-js-file_group{"data-index" => "#{@product.product_images.count}"}
+                    = form.file_field :image, name: "product[product_images_attributes][#{@product.product_images.count}][image]", id: "products_images_attributes_#{@product.product_images.count}_image", class: 'products_edit-js-file', style: "display:none"
         .products_new-title
           .products_new-product__headline
             .products_new-product__headline--title 商品名

--- a/app/views/products/edit.html.haml
+++ b/app/views/products/edit.html.haml
@@ -1,6 +1,7 @@
 .products_new-header
 .products_new-main
   .products_new-main__form
+    = render 'layouts/notifications'
     .products_new-main__form--product_new
       = form_with model: @product, local: true, id:"new_product" do |form|
         .products_new-newimage

--- a/app/views/products/edit.html.haml
+++ b/app/views/products/edit.html.haml
@@ -7,7 +7,7 @@
           .products_new-product__headline
             .products_new-product__headline--title 出品画像
             .products_new-product__headline--required 必須
-          %p.products_new-product__explanation 最大10枚までアップロードできます
+          %p.products_new-product__explanation 最大5枚までアップロードできます
           .products_edit-image
             .products_edit-image-box
               .products_edit-content
@@ -20,7 +20,7 @@
                           削除
                 = form.fields_for :product_images do |image|
                   - if @product.persisted?
-                    = image.check_box :_destroy, include_hidden: false, data:{ index: image.index },class: 'products_edit-hidden-destroy'
+                    = image.check_box :_destroy, class: "delete-check-box-#{image.index}"
               .products_edit-lower-box
                 %label.products_edit-lower-box__label
                   .products_edit-js-file_group{"data-index" => "#{@product.product_images.count}"}

--- a/app/views/products/edit.html.haml
+++ b/app/views/products/edit.html.haml
@@ -20,7 +20,7 @@
                           削除
                 = form.fields_for :product_images do |image|
                   - if @product.persisted?
-                    = image.check_box :_destroy, class: "delete-check-box-#{image.index}"
+                    = image.check_box :_destroy, class: "delete-check-box-#{image.index}", style:"display:none;"
               .products_edit-lower-box
                 %label.products_edit-lower-box__label
                   .products_edit-js-file_group{"data-index" => "#{@product.product_images.count}"}

--- a/app/views/products/new.html.haml
+++ b/app/views/products/new.html.haml
@@ -7,7 +7,7 @@
           .products_new-product__headline
             .products_new-product__headline--title 出品画像
             .products_new-product__headline--required 必須
-          %p.products_new-product__explanation 最大10枚までアップロードできます
+          %p.products_new-product__explanation 最大5枚までアップロードできます
           .products_new-image
             .products_new-image-box
               .products_new-content
@@ -33,7 +33,12 @@
               .products_new-product__headline--title カテゴリー
               .products_new-product__headline--required 必須
             .products_new-product_explanation__category--box
-              = form.select :category, @category_parent_array, {}, {class: "products_new-product_explanation__category--parent",id: 'parent_category'}
+              - if @product.persisted?
+                = form.select :parent_name, @category_parent_array, {selected: @product.category.parent.parent.name}, {class: "products_new-product_explanation__category--parent",id: 'parent_category'}
+                = form.select :child_id, options_for_select(@category_children_array.map{|b| [b.name, b.id, {data:{category: b.id}}]}, {prompt: "選択してください", selected: @product.category.parent.id}),{},  {class: "products_new-product_explanation__category--children",id: 'children_category'}
+                = form.select :category_id, options_for_select(@category_grandchildren_array.map{|b| [b.name, b.id, {data:{category: b.id}}]}, {prompt: "選択してください", selected: @product.category.id}),{}, {class: "products_new-product_explanation__category--grandchildren",id: 'grandchildren_category'}
+              - else
+                = form.select :category, @category_parent_array, {}, {class: "products_new-product_explanation__category--parent",id: 'parent_category'}
           .products_new-product_explanation__brand
             .products_new-product__headline
               .products_new-product__headline--title ブランド

--- a/app/views/products/new.html.haml
+++ b/app/views/products/new.html.haml
@@ -13,9 +13,9 @@
               .products_new-content
               .products_new-uploader-box
                 %label.products_new-uploader__label
-                  = form.fields_for :product_images do |i|
-                    .product_newt-js-file_group{"data-index" => "#{@product.product_images.index}"}
-                      = form.file_field :image, class: 'product_new-js-file', style: "display:none"
+                  = form.fields_for :product_images do |image|
+                    .products_newt-js-file_group{"data-index" => "#{@product.product_images.index}"}
+                      = image.file_field :image, class: 'products_new-js-file', style: "display:none"
         .products_new-title
           .products_new-product__headline
             .products_new-product__headline--title 商品名

--- a/app/views/products/new.html.haml
+++ b/app/views/products/new.html.haml
@@ -1,13 +1,14 @@
 .products_new-header
 .products_new-main
   .products_new-main__form
+    = render 'layouts/notifications'
     .products_new-main__form--product_new
       = form_with model: @product, local: true, id:"new_product" do |form|
         .products_new-newimage
           .products_new-product__headline
             .products_new-product__headline--title 出品画像
             .products_new-product__headline--required 必須
-          %p.products_new-product__explanation 最大5枚までアップロードできます
+          %p.products_new-product__explanation 最大10枚までアップロードできます
           .products_new-image
             .products_new-image-box
               .products_new-content
@@ -33,12 +34,7 @@
               .products_new-product__headline--title カテゴリー
               .products_new-product__headline--required 必須
             .products_new-product_explanation__category--box
-              - if @product.persisted?
-                = form.select :parent_name, @category_parent_array, {selected: @product.category.parent.parent.name}, {class: "products_new-product_explanation__category--parent",id: 'parent_category'}
-                = form.select :child_id, options_for_select(@category_children_array.map{|b| [b.name, b.id, {data:{category: b.id}}]}, {prompt: "選択してください", selected: @product.category.parent.id}),{},  {class: "products_new-product_explanation__category--children",id: 'children_category'}
-                = form.select :category_id, options_for_select(@category_grandchildren_array.map{|b| [b.name, b.id, {data:{category: b.id}}]}, {prompt: "選択してください", selected: @product.category.id}),{}, {class: "products_new-product_explanation__category--grandchildren",id: 'grandchildren_category'}
-              - else
-                = form.select :category, @category_parent_array, {}, {class: "products_new-product_explanation__category--parent",id: 'parent_category'}
+              = form.select :category, @category_parent_array, {}, {class: "products_new-product_explanation__category--parent",id: 'parent_category'}
           .products_new-product_explanation__brand
             .products_new-product__headline
               .products_new-product__headline--title ブランド


### PR DESCRIPTION
# What
商品出品ページ、商品編集ページそれぞれ画像を５枚選択でき、プレビューを表示できるようにした。
商品編集時に既に登録されている画像を消した時、DB上でも削除できるよう設定。
商品出品ページ、商品編集ページそれぞれ投稿が失敗した時のエラーハンドリングとして具ラッシュメッセージを設定。