### PR TITLE
URLの直打ち防止等

### DIFF
--- a/app/controllers/products_controller.rb
+++ b/app/controllers/products_controller.rb
@@ -134,7 +134,7 @@ class ProductsController < ApplicationController
   end
 
   def move_to_index
-    redirect_to root_path unless user_signed_in?
+    redirect_to new_user_session_path unless user_signed_in?
   end
 
   def move_to_index_buy

--- a/app/controllers/products_controller.rb
+++ b/app/controllers/products_controller.rb
@@ -1,5 +1,8 @@
 class ProductsController < ApplicationController
   before_action :move_to_index, except: [:show]
+  before_action :move_to_index_buy, only: [:buy, :purchase]
+  before_action :move_to_index_purchased, only: [:buy, :purchase]
+  before_action :move_to_index_destroy, only: [:destroy]
 
   def new
     @product = Product.new
@@ -132,6 +135,21 @@ class ProductsController < ApplicationController
 
   def move_to_index
     redirect_to root_path unless user_signed_in?
+  end
+
+  def move_to_index_buy
+    @product = Product.find(params[:id])
+    redirect_to root_path if current_user.id == @product.user_id
+  end
+
+  def move_to_index_purchased
+    @product = Product.find(params[:id])
+    redirect_to root_path if @product.buyer_id.present? 
+  end
+
+  def move_to_index_destroy
+    @product = Product.find(params[:id])
+    redirect_to root_path unless current_user.id == @product.user_id
   end
 
 end


### PR DESCRIPTION
# What
## メンターさんからの課題`1~8,11`実装
>1.ログインしていないユーザーが商品一覧・商品詳細以外のページへ行こうとしたらログインページへリダイレクトさせる
2.自身が出品した商品は「購入画面へ進む」ボタンを押せなくなっている
3.自身が出品した商品の購入画面へURLを直打ちしても飛べないようになっている
4.自身が出品した商品は、支払いを作成するアクション(Payjp::Charge.createをするアクション)を動かせないようになっている
5.一度購入された商品は「購入画面へ進む」ボタンを押せなくなっている
6.一度購入された商品の購入画面へURLを直打ちしても飛べなくなっている
7.一度購入された商品は、支払いを作成するアクション(Payjp::Charge.createをするアクション)を動かせないようになっている
8.他人の商品は「編集する」ボタンを押せなくなっている
11.他人の商品の削除アクション(products#destroy等)を動かせないようになっている(コントローラで対策する)
https://techcamp-expert.slack.com/archives/C011R65BE78/p1588567176007600

# Why
- メンターさんからの課題
- 予期しない動作の禁止


# Details
> 1.ログインしていないユーザーが商品一覧・商品詳細以外のページへ行こうとしたらログインページへリダイレクトさせる

`products_controller`
```ruby
before_action :move_to_index, except: [:show]

def move_to_index
  redirect_to new_user_session_path unless user_signed_in?
end
```
***
> 3.自身が出品した商品の購入画面へURLを直打ちしても飛べないようになっている
> 4.自身が出品した商品は、支払いを作成するアクション(Payjp::Charge.createをするアクション)を動かせないようになっている

`products_controller`
```ruby
before_action :move_to_index_buy, only: [:buy, :purchase]

def move_to_index_buy
  @product = Product.find(params[:id])
  redirect_to root_path if current_user.id == @product.user_id
end
```
***
> 6.一度購入された商品の購入画面へURLを直打ちしても飛べなくなっている
> 7.一度購入された商品は、支払いを作成するアクション(Payjp::Charge.createをするアクション)を動かせないようになっている

`products_controller`
```ruby
before_action :move_to_index_purchased, only: [:buy, :purchase]

def move_to_index_purchased
  @product = Product.find(params[:id])
  redirect_to root_path if @product.buyer_id.present? 
end
```
***
> 11. 他人の商品の削除アクション(products#destroy等)を動かせないようになっている(コントローラで対策する)

`products_controller`
```ruby
  before_action :move_to_index_destroy, only: [:destroy]

  def move_to_index_destroy
    @product = Product.find(params[:id])
    redirect_to root_path unless current_user.id == @product.user_id
  end
```