### PR TITLE
URL直打ち防止 edit,update

### DIFF
--- a/app/controllers/products_controller.rb
+++ b/app/controllers/products_controller.rb
@@ -61,7 +61,8 @@ class ProductsController < ApplicationController
         redirect_to action: 'edit'
       end
     else
-      render product_path(@product.id)
+      flash[:alert] = '投稿に失敗しました'
+      redirect_to action: 'edit'
     end
   end
 

--- a/app/controllers/products_controller.rb
+++ b/app/controllers/products_controller.rb
@@ -3,6 +3,7 @@ class ProductsController < ApplicationController
   before_action :move_to_index_buy, only: [:buy, :purchase]
   before_action :move_to_index_purchased, only: [:buy, :purchase]
   before_action :move_to_index_destroy, only: [:destroy]
+  before_action :move_to_index_edit, only: [:edit]
 
   def new
     @product = Product.new
@@ -151,6 +152,11 @@ class ProductsController < ApplicationController
   def move_to_index_destroy
     @product = Product.find(params[:id])
     redirect_to root_path unless current_user.id == @product.user_id
+  end
+
+  def move_to_index_edit
+    @product = Product.find(params[:id])
+    redirect_to product_path(@product.id) unless current_user.id == @product.user_id
   end
 
 end


### PR DESCRIPTION
# What
9. 他人の商品の編集画面へURLを直打ちしても飛べないようになっている
→before_actionを設定

10. 他人の商品の更新アクション(products#update等)を動かせないようになっている(コントローラで対策する)
→redirect_to action: 'edit'でアラート を表示

12. 商品出品時に画像無しでは出品できないようになっている
→実装済
13. 商品編集時に、画像を全て削除した状態で更新できないようになっている
→実装済